### PR TITLE
Update movement input to AZERTY keyboard

### DIFF
--- a/ProjectSettings/InputManager.asset
+++ b/ProjectSettings/InputManager.asset
@@ -11,7 +11,7 @@ InputManager:
     descriptiveNegativeName:
     negativeButton: left
     positiveButton: right
-    altNegativeButton: a
+    altNegativeButton: q
     altPositiveButton: d
     gravity: 3
     dead: 0.001
@@ -28,7 +28,7 @@ InputManager:
     negativeButton: down
     positiveButton: up
     altNegativeButton: s
-    altPositiveButton: w
+    altPositiveButton: z
     gravity: 3
     dead: 0.001
     sensitivity: 3
@@ -346,7 +346,7 @@ InputManager:
     descriptiveName:
     descriptiveNegativeName:
     negativeButton: e
-    positiveButton: q
+    positiveButton: a
     altNegativeButton: joystick button 4
     altPositiveButton: joystick button 3
     gravity: 1000


### PR DESCRIPTION
Replaced default movement keys to support AZERTY layout:
- Q instead of A (left)
- Z instead of W (forward)
- A instead of Q (switch weapon)